### PR TITLE
Permit noop functions in TS

### DIFF
--- a/index.js
+++ b/index.js
@@ -186,6 +186,9 @@ module.exports = {
         // prefer T[] style of arrays
         '@typescript-eslint/array-type': 2,
 
+        // allow noop functions
+        '@typescript-eslint/no-empty-function': 0,
+
         // prevent types from being redundantly specified in JSDoc comments
         'jsdoc/no-types': 2,
       },


### PR DESCRIPTION
This allows:

```ts
function foo() {}
const bar = () => {}
```

(Previously we had to include a comment. But I don't think the lack of clarity has been a problem for us in practice.)