### PR TITLE
Remove Prettier plugin and associated rule

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "bracketSpacing": false,
+  "printWidth": 100,
+  "semi": false,
+  "singleQuote": true
+}

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,6 +1,0 @@
-{
-  "bracketSpacing": false,
-  "printWidth": 100,
-  "semi": false,
-  "singleQuote": true
-}

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Since the upstream config is well-maintained and justified, we try to stick as c
 
 ## Usage
 
-To add linting to a project, first install ESLint, Prettier, TypeScript, and this config as development dependencies:
+To add linting to a project, first install ESLint, TypeScript, and this config as development dependencies:
 
 ```sh
-$ npm i -D eslint prettier typescript eslint-config-kensho
+$ npm i -D eslint typescript eslint-config-kensho
 ```
 
 Add an [**ESLint config**](http://eslint.org/docs/user-guide/configuring) which extends the config, e.g.:

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 module.exports = {
   extends: ['airbnb', 'airbnb/hooks', 'plugin:import/typescript', 'prettier', 'prettier/react'],
-  plugins: ['prettier', 'jsdoc'],
+  plugins: ['jsdoc'],
   parser: 'babel-eslint',
   env: {
     // allow browser globals
@@ -70,16 +70,6 @@ module.exports = {
 
     // https://github.com/prettier/eslint-config-prettier#arrow-body-style-and-prefer-arrow-callback
     'prefer-arrow-callback': [2, {allowNamedFunctions: false, allowUnboundThis: true}],
-
-    'prettier/prettier': [
-      2,
-      {
-        printWidth: 100,
-        semi: false,
-        singleQuote: true,
-        bracketSpacing: false,
-      },
-    ],
 
     // disallow .jsx files for consistency
     'react/jsx-filename-extension': 0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2571,14 +2571,6 @@
         "language-tags": "^1.0.5"
       }
     },
-    "eslint-plugin-prettier": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.4.tgz",
-      "integrity": "sha512-jZDa8z76klRqo+TdGDTFJSavwbnWK2ZpqGKNZ+VvweMW516pDUMmQ2koXvxEE4JhzNvTv+radye/bWGBmA6jmg==",
-      "requires": {
-        "prettier-linter-helpers": "^1.0.0"
-      }
-    },
     "eslint-plugin-react": {
       "version": "7.20.6",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.20.6.tgz",
@@ -2980,11 +2972,6 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
-    },
-    "fast-diff": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w=="
     },
     "fast-glob": {
       "version": "3.2.4",
@@ -5909,14 +5896,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz",
       "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==",
       "dev": true
-    },
-    "prettier-linter-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
-      "requires": {
-        "fast-diff": "^1.1.2"
-      }
     },
     "pretty-format": {
       "version": "26.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -950,6 +950,12 @@
         }
       }
     },
+    "@kensho-technologies/prettier-config": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@kensho-technologies/prettier-config/-/prettier-config-0.1.0.tgz",
+      "integrity": "sha512-McX8Eqj1Ls0jBa/s/9Q9l2y9xQWrVDTw/pv7cVvdoJzSsqa0xGNNSvhU2BBRFozYRlC6rgQwPZprLbKQl4TEUg==",
+      "dev": true
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "files": [
     "index.js"
   ],
+  "prettier": "@kensho-technologies/prettier-config",
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^4.2.0",
     "@typescript-eslint/parser": "^4.2.0",
@@ -27,6 +28,7 @@
     "eslint-plugin-react-hooks": "^4.1.2"
   },
   "devDependencies": {
+    "@kensho-technologies/prettier-config": "^0.1.0",
     "eslint": "^7.9.0",
     "jest": "^26.4.2",
     "prettier": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "license": "MIT",
   "repository": "kensho/eslint-config-kensho",
   "scripts": {
-    "test": "eslint . && jest",
+    "fix": "prettier -w . && eslint --fix .",
+    "test": "prettier -c . && eslint . && jest",
     "prepublishOnly": "npm test"
   },
   "files": [
@@ -22,7 +23,6 @@
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-jsdoc": "^30.5.1",
     "eslint-plugin-jsx-a11y": "^6.3.1",
-    "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-react": "^7.20.6",
     "eslint-plugin-react-hooks": "^4.1.2"
   },


### PR DESCRIPTION
In favor of using Prettier directly, so as to format non-JS/TS files.